### PR TITLE
Typo in example artifactory backend subpath

### DIFF
--- a/website/docs/backends/types/artifactory.html.md
+++ b/website/docs/backends/types/artifactory.html.md
@@ -28,7 +28,7 @@ terraform {
     password = "AmyFarrahFowler"
     url      = "https://custom.artifactoryonline.com/artifactory"
     repo     = "foo"
-    subpath  = "teraraform-bar"
+    subpath  = "terraform-bar"
   }
 }
 ```


### PR DESCRIPTION
Simple typo discovered while researching backend configuration